### PR TITLE
Replace calls of deprecated functions for getting subfields of a PVStructure

### DIFF
--- a/src/pvaccess/NtTable.cpp
+++ b/src/pvaccess/NtTable.cpp
@@ -140,12 +140,12 @@ boost::python::list NtTable::getColumn(int column) const
 }
 void NtTable::setDescriptor(const std::string& descriptor)
 {
-        pvStructurePtr->getStringField(DescriptorFieldKey)->put(descriptor);
+        pvStructurePtr->getSubField<epics::pvData::PVString>(DescriptorFieldKey)->put(descriptor);
 }
 
 std::string NtTable::getDescriptor() const
 {
-        return pvStructurePtr->getStringField(DescriptorFieldKey)->get();
+        return pvStructurePtr->getSubField<epics::pvData::PVString>(DescriptorFieldKey)->get();
 }
 
 PvTimeStamp NtTable::getTimeStamp() const

--- a/src/pvaccess/PvAlarm.cpp
+++ b/src/pvaccess/PvAlarm.cpp
@@ -54,31 +54,31 @@ PvAlarm::~PvAlarm()
 
 void PvAlarm::setSeverity(int severity)
 {
-    pvStructurePtr->getIntField(SeverityFieldKey)->put(severity);
+    pvStructurePtr->getSubField<epics::pvData::PVInt>(SeverityFieldKey)->put(severity);
 }
 
 int PvAlarm::getSeverity() const
 {
-    return pvStructurePtr->getIntField(SeverityFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVInt>(SeverityFieldKey)->get();
 }
 
 void PvAlarm::setStatus(int status)
 {
-    pvStructurePtr->getIntField(StatusFieldKey)->put(status);
+    pvStructurePtr->getSubField<epics::pvData::PVInt>(StatusFieldKey)->put(status);
 }
 
 int PvAlarm::getStatus() const
 {
-    return pvStructurePtr->getIntField(StatusFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVInt>(StatusFieldKey)->get();
 }
 
 void PvAlarm::setMessage(const std::string& message)
 {
-    pvStructurePtr->getStringField(MessageFieldKey)->put(message);
+    pvStructurePtr->getSubField<epics::pvData::PVString>(MessageFieldKey)->put(message);
 }
 
 std::string PvAlarm::getMessage() const
 {
-    return pvStructurePtr->getStringField(MessageFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVString>(MessageFieldKey)->get();
 }
 

--- a/src/pvaccess/PvBoolean.cpp
+++ b/src/pvaccess/PvBoolean.cpp
@@ -27,12 +27,12 @@ PvBoolean::~PvBoolean()
 
 void PvBoolean::set(bool b) 
 {
-    pvStructurePtr->getBooleanField(ValueFieldKey)->put(b);
+    pvStructurePtr->getSubField<epics::pvData::PVBoolean>(ValueFieldKey)->put(b);
 }
 
 bool PvBoolean::get() const 
 {
-    return pvStructurePtr->getBooleanField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVBoolean>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvByte.cpp
+++ b/src/pvaccess/PvByte.cpp
@@ -27,12 +27,12 @@ PvByte::~PvByte()
 
 void PvByte::set(char c) 
 {
-    pvStructurePtr->getByteField(ValueFieldKey)->put(c);
+    pvStructurePtr->getSubField<epics::pvData::PVByte>(ValueFieldKey)->put(c);
 }
 
 char PvByte::get() const 
 {
-    return pvStructurePtr->getByteField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVByte>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvFloat.cpp
+++ b/src/pvaccess/PvFloat.cpp
@@ -27,12 +27,12 @@ PvFloat::~PvFloat()
 
 void PvFloat::set(float f) 
 {
-    pvStructurePtr->getFloatField(ValueFieldKey)->put(f);
+    pvStructurePtr->getSubField<epics::pvData::PVFloat>(ValueFieldKey)->put(f);
 }
 
 float PvFloat::get() const 
 {
-    return pvStructurePtr->getFloatField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVFloat>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvInt.cpp
+++ b/src/pvaccess/PvInt.cpp
@@ -27,12 +27,12 @@ PvInt::~PvInt()
 
 void PvInt::set(int i) 
 {
-    pvStructurePtr->getIntField(ValueFieldKey)->put(i);
+    pvStructurePtr->getSubField<epics::pvData::PVInt>(ValueFieldKey)->put(i);
 }
 
 int PvInt::get() const 
 {
-    return pvStructurePtr->getIntField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVInt>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvLong.cpp
+++ b/src/pvaccess/PvLong.cpp
@@ -27,12 +27,12 @@ PvLong::~PvLong()
 
 void PvLong::set(long long ll) 
 {
-    pvStructurePtr->getLongField(ValueFieldKey)->put(ll);
+    pvStructurePtr->getSubField<epics::pvData::PVLong>(ValueFieldKey)->put(ll);
 }
 
 long long PvLong::get() const 
 {
-    return pvStructurePtr->getLongField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVLong>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvScalar.cpp
+++ b/src/pvaccess/PvScalar.cpp
@@ -49,51 +49,51 @@ double PvScalar::toDouble() const
     double value;
     switch (scalarType) {
         case epics::pvData::pvBoolean: {
-            value = pvStructurePtr->getBooleanField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVBoolean>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvByte: {
-            value = pvStructurePtr->getByteField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVByte>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvUByte: {
-            value = pvStructurePtr->getUByteField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVUByte>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvShort: {
-            value = pvStructurePtr->getShortField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVShort>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvUShort: {
-            value = pvStructurePtr->getUShortField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVUShort>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvInt: {
-            value = pvStructurePtr->getIntField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVInt>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvUInt: {
-            value = pvStructurePtr->getUIntField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVUInt>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvLong: {
-            value = pvStructurePtr->getLongField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVLong>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvULong: {
-            value = pvStructurePtr->getULongField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVULong>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvFloat: {
-            value = pvStructurePtr->getFloatField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVFloat>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvDouble: {
-            value = pvStructurePtr->getDoubleField(ValueFieldKey)->get();
+            value = pvStructurePtr->getSubField<epics::pvData::PVDouble>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvString: {
-            std::string s = pvStructurePtr->getStringField(ValueFieldKey)->get();
+            std::string s = pvStructurePtr->getSubField<epics::pvData::PVString>(ValueFieldKey)->get();
             value = atof(s.c_str());
             break;
         }
@@ -110,51 +110,51 @@ std::string PvScalar::toString() const
     epics::pvData::ScalarType scalarType = PyPvDataUtility::getScalarType(ValueFieldKey, pvStructurePtr);
     switch (scalarType) {
         case epics::pvData::pvBoolean: {
-            oss << static_cast<bool>(pvStructurePtr->getBooleanField(ValueFieldKey)->get());
+            oss << static_cast<bool>(pvStructurePtr->getSubField<epics::pvData::PVBoolean>(ValueFieldKey)->get());
             break;
         }
         case epics::pvData::pvByte: {
-            oss << pvStructurePtr->getByteField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVByte>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvUByte: {
-            oss << pvStructurePtr->getUByteField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVUByte>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvShort: {
-            oss << pvStructurePtr->getShortField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVShort>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvUShort: {
-            oss << pvStructurePtr->getUShortField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVUShort>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvInt: {
-            oss << pvStructurePtr->getIntField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVInt>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvUInt: {
-            oss << pvStructurePtr->getUIntField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVUInt>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvLong: {
-            oss << pvStructurePtr->getLongField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVLong>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvULong: {
-            oss << pvStructurePtr->getULongField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVULong>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvFloat: {
-            oss << pvStructurePtr->getFloatField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVFloat>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvDouble: {
-            oss << pvStructurePtr->getDoubleField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVDouble>(ValueFieldKey)->get();
             break;
         }
         case epics::pvData::pvString: {
-            oss << pvStructurePtr->getStringField(ValueFieldKey)->get();
+            oss << pvStructurePtr->getSubField<epics::pvData::PVString>(ValueFieldKey)->get();
             break;
         }
         default: {
@@ -169,62 +169,62 @@ PvScalar& PvScalar::add(int i)
     epics::pvData::ScalarType scalarType = PyPvDataUtility::getScalarType(ValueFieldKey, pvStructurePtr);
     switch (scalarType) {
         case epics::pvData::pvBoolean: {
-            epics::pvData::PVBooleanPtr fieldPtr = pvStructurePtr->getBooleanField(ValueFieldKey);
+            epics::pvData::PVBooleanPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVBoolean>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvByte: {
-            epics::pvData::PVBytePtr fieldPtr = pvStructurePtr->getByteField(ValueFieldKey);
+            epics::pvData::PVBytePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVByte>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvUByte: {
-            epics::pvData::PVUBytePtr fieldPtr = pvStructurePtr->getUByteField(ValueFieldKey);
+            epics::pvData::PVUBytePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUByte>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvShort: {
-            epics::pvData::PVShortPtr fieldPtr = pvStructurePtr->getShortField(ValueFieldKey);
+            epics::pvData::PVShortPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVShort>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvUShort: {
-            epics::pvData::PVUShortPtr fieldPtr = pvStructurePtr->getUShortField(ValueFieldKey);
+            epics::pvData::PVUShortPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUShort>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvInt: {
-            epics::pvData::PVIntPtr fieldPtr = pvStructurePtr->getIntField(ValueFieldKey);
+            epics::pvData::PVIntPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVInt>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvUInt: {
-            epics::pvData::PVUIntPtr fieldPtr = pvStructurePtr->getUIntField(ValueFieldKey);
+            epics::pvData::PVUIntPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUInt>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvLong: {
-            epics::pvData::PVLongPtr fieldPtr = pvStructurePtr->getLongField(ValueFieldKey);
+            epics::pvData::PVLongPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVLong>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvULong: {
-            epics::pvData::PVULongPtr fieldPtr = pvStructurePtr->getULongField(ValueFieldKey);
+            epics::pvData::PVULongPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVULong>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvFloat: {
-            epics::pvData::PVFloatPtr fieldPtr = pvStructurePtr->getFloatField(ValueFieldKey);
+            epics::pvData::PVFloatPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVFloat>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvDouble: {
-            epics::pvData::PVDoublePtr fieldPtr = pvStructurePtr->getDoubleField(ValueFieldKey);
+            epics::pvData::PVDoublePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVDouble>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+i);
             break;
         }
         case epics::pvData::pvString: {
-            epics::pvData::PVStringPtr fieldPtr = pvStructurePtr->getStringField(ValueFieldKey);
+            epics::pvData::PVStringPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVString>(ValueFieldKey);
             fieldPtr->put(fieldPtr->get()+StringUtility::toString(i));
             break;
         }

--- a/src/pvaccess/PvShort.cpp
+++ b/src/pvaccess/PvShort.cpp
@@ -27,12 +27,12 @@ PvShort::~PvShort()
 
 void PvShort::set(short s) 
 {
-    pvStructurePtr->getShortField(ValueFieldKey)->put(s);
+    pvStructurePtr->getSubField<epics::pvData::PVShort>(ValueFieldKey)->put(s);
 }
 
 short PvShort::get() const 
 {
-    return pvStructurePtr->getShortField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVShort>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvString.cpp
+++ b/src/pvaccess/PvString.cpp
@@ -27,12 +27,12 @@ PvString::~PvString()
 
 void PvString::set(const std::string& s) 
 {
-    pvStructurePtr->getStringField(ValueFieldKey)->put(s);
+    pvStructurePtr->getSubField<epics::pvData::PVString>(ValueFieldKey)->put(s);
 }
 
 std::string PvString::get() const 
 {
-    return pvStructurePtr->getStringField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVString>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvTimeStamp.cpp
+++ b/src/pvaccess/PvTimeStamp.cpp
@@ -64,31 +64,31 @@ PvTimeStamp::~PvTimeStamp()
 
 void PvTimeStamp::setSecondsPastEpoch(long long secondsPastEpoch)
 {
-    pvStructurePtr->getLongField(SecondsPastEpochFieldKey)->put(secondsPastEpoch);
+    pvStructurePtr->getSubField<epics::pvData::PVLong>(SecondsPastEpochFieldKey)->put(secondsPastEpoch);
 }
 
 long long PvTimeStamp::getSecondsPastEpoch() const
 {
-    return pvStructurePtr->getLongField(SecondsPastEpochFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVLong>(SecondsPastEpochFieldKey)->get();
 }
 
 void PvTimeStamp::setNanoseconds(int nanoseconds)
 {
-    pvStructurePtr->getIntField(NanosecondsFieldKey)->put(nanoseconds);
+    pvStructurePtr->getSubField<epics::pvData::PVInt>(NanosecondsFieldKey)->put(nanoseconds);
 }
 
 int PvTimeStamp::getNanoseconds() const
 {
-    return pvStructurePtr->getIntField(NanosecondsFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVInt>(NanosecondsFieldKey)->get();
 }
 
 void PvTimeStamp::setUserTag(int userTag)
 {
-    pvStructurePtr->getIntField(UserTagFieldKey)->put(userTag);
+    pvStructurePtr->getSubField<epics::pvData::PVInt>(UserTagFieldKey)->put(userTag);
 }
 
 int PvTimeStamp::getUserTag() const
 {
-    return pvStructurePtr->getIntField(UserTagFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVInt>(UserTagFieldKey)->get();
 }
 

--- a/src/pvaccess/PvUByte.cpp
+++ b/src/pvaccess/PvUByte.cpp
@@ -27,12 +27,12 @@ PvUByte::~PvUByte()
 
 void PvUByte::set(unsigned char uc) 
 {
-    pvStructurePtr->getUByteField(ValueFieldKey)->put(uc);
+    pvStructurePtr->getSubField<epics::pvData::PVUByte>(ValueFieldKey)->put(uc);
 }
 
 unsigned char PvUByte::get() const 
 {
-    return pvStructurePtr->getUByteField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVUByte>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvUInt.cpp
+++ b/src/pvaccess/PvUInt.cpp
@@ -27,12 +27,12 @@ PvUInt::~PvUInt()
 
 void PvUInt::set(unsigned int ui) 
 {
-    pvStructurePtr->getUIntField(ValueFieldKey)->put(ui);
+    pvStructurePtr->getSubField<epics::pvData::PVUInt>(ValueFieldKey)->put(ui);
 }
 
 unsigned int PvUInt::get() const 
 {
-    return pvStructurePtr->getUIntField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVUInt>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvULong.cpp
+++ b/src/pvaccess/PvULong.cpp
@@ -27,12 +27,12 @@ PvULong::~PvULong()
 
 void PvULong::set(unsigned long long ull) 
 {
-    pvStructurePtr->getULongField(ValueFieldKey)->put(ull);
+    pvStructurePtr->getSubField<epics::pvData::PVULong>(ValueFieldKey)->put(ull);
 }
 
 unsigned long long PvULong::get() const 
 {
-    return pvStructurePtr->getULongField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVULong>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PvUShort.cpp
+++ b/src/pvaccess/PvUShort.cpp
@@ -27,12 +27,12 @@ PvUShort::~PvUShort()
 
 void PvUShort::set(unsigned short us) 
 {
-    pvStructurePtr->getUShortField(ValueFieldKey)->put(us);
+    pvStructurePtr->getSubField<epics::pvData::PVUShort>(ValueFieldKey)->put(us);
 }
 
 unsigned short PvUShort::get() const 
 {
-    return pvStructurePtr->getUShortField(ValueFieldKey)->get();
+    return pvStructurePtr->getSubField<epics::pvData::PVUShort>(ValueFieldKey)->get();
 }
 
 

--- a/src/pvaccess/PyPvDataUtility.cpp
+++ b/src/pvaccess/PyPvDataUtility.cpp
@@ -48,7 +48,7 @@ std::string getValueOrSelectedUnionFieldName(const epics::pvData::PVStructurePtr
     std::string fieldName = PvaConstants::ValueFieldKey;
     epics::pvData::PVFieldPtr pvFieldPtr = pvStructurePtr->getSubField(fieldName);
     if (!pvFieldPtr) {
-        epics::pvData::PVUnionPtr pvUnionPtr = pvStructurePtr->getUnionField(fieldName);
+        epics::pvData::PVUnionPtr pvUnionPtr = pvStructurePtr->getSubField<epics::pvData::PVUnion>(fieldName);
         if (!pvUnionPtr) {
             throw InvalidRequest("Field " + fieldName + " is not a union");
         }
@@ -108,7 +108,7 @@ epics::pvData::StructureConstPtr getStructure(const std::string& fieldName, cons
 epics::pvData::PVStructurePtr getStructureField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr)
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVStructurePtr pvStructurePtr2 = pvStructurePtr->getStructureField(fieldName);
+    epics::pvData::PVStructurePtr pvStructurePtr2 = pvStructurePtr->getSubField<epics::pvData::PVStructure>(fieldName);
     if (!pvStructurePtr2) {
         throw InvalidRequest("Field " + fieldName + " is not a structure");
     }
@@ -118,7 +118,7 @@ epics::pvData::PVStructurePtr getStructureField(const std::string& fieldName, co
 epics::pvData::PVStructureArrayPtr getStructureArrayField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr)
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVStructureArrayPtr pvStructureArrayPtr = pvStructurePtr->getStructureArrayField(fieldName);
+    epics::pvData::PVStructureArrayPtr pvStructureArrayPtr = pvStructurePtr->getSubField<epics::pvData::PVStructureArray>(fieldName);
     if (!pvStructureArrayPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a structure array");
     }
@@ -128,7 +128,7 @@ epics::pvData::PVStructureArrayPtr getStructureArrayField(const std::string& fie
 epics::pvData::PVUnionPtr getUnionField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr)
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVUnionPtr pvUnionPtr = pvStructurePtr->getUnionField(fieldName);
+    epics::pvData::PVUnionPtr pvUnionPtr = pvStructurePtr->getSubField<epics::pvData::PVUnion>(fieldName);
     if (!pvUnionPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an union");
     }
@@ -166,7 +166,7 @@ void setUnionField(const epics::pvData::PVFieldPtr& pvFrom, epics::pvData::PVUni
 epics::pvData::PVUnionArrayPtr getUnionArrayField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr)
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVUnionArrayPtr pvUnionArrayPtr = pvStructurePtr->getUnionArrayField(fieldName);
+    epics::pvData::PVUnionArrayPtr pvUnionArrayPtr = pvStructurePtr->getSubField<epics::pvData::PVUnionArray>(fieldName);
     if (!pvUnionArrayPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an union array");
     }
@@ -176,7 +176,7 @@ epics::pvData::PVUnionArrayPtr getUnionArrayField(const std::string& fieldName, 
 epics::pvData::PVBooleanPtr getBooleanField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVBooleanPtr fieldPtr = pvStructurePtr->getBooleanField(fieldName);
+    epics::pvData::PVBooleanPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVBoolean>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a boolean");
     }
@@ -186,7 +186,7 @@ epics::pvData::PVBooleanPtr getBooleanField(const std::string& fieldName, const 
 epics::pvData::PVBytePtr getByteField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVBytePtr fieldPtr = pvStructurePtr->getByteField(fieldName);
+    epics::pvData::PVBytePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVByte>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a byte");
     }
@@ -196,7 +196,7 @@ epics::pvData::PVBytePtr getByteField(const std::string& fieldName, const epics:
 epics::pvData::PVUBytePtr getUByteField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVUBytePtr fieldPtr = pvStructurePtr->getUByteField(fieldName);
+    epics::pvData::PVUBytePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUByte>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an unsigned byte");
     }
@@ -206,7 +206,7 @@ epics::pvData::PVUBytePtr getUByteField(const std::string& fieldName, const epic
 epics::pvData::PVShortPtr getShortField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVShortPtr fieldPtr = pvStructurePtr->getShortField(fieldName);
+    epics::pvData::PVShortPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVShort>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a short");
     }
@@ -216,7 +216,7 @@ epics::pvData::PVShortPtr getShortField(const std::string& fieldName, const epic
 epics::pvData::PVUShortPtr getUShortField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVUShortPtr fieldPtr = pvStructurePtr->getUShortField(fieldName);
+    epics::pvData::PVUShortPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUShort>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an unsigned short");
     }
@@ -226,7 +226,7 @@ epics::pvData::PVUShortPtr getUShortField(const std::string& fieldName, const ep
 epics::pvData::PVIntPtr getIntField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVIntPtr fieldPtr = pvStructurePtr->getIntField(fieldName);
+    epics::pvData::PVIntPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVInt>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an int");
     }
@@ -236,7 +236,7 @@ epics::pvData::PVIntPtr getIntField(const std::string& fieldName, const epics::p
 epics::pvData::PVUIntPtr getUIntField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVUIntPtr fieldPtr = pvStructurePtr->getUIntField(fieldName);
+    epics::pvData::PVUIntPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUInt>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an unsigned int");
     }
@@ -246,7 +246,7 @@ epics::pvData::PVUIntPtr getUIntField(const std::string& fieldName, const epics:
 epics::pvData::PVLongPtr getLongField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVLongPtr fieldPtr = pvStructurePtr->getLongField(fieldName);
+    epics::pvData::PVLongPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVLong>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a long");
     }
@@ -256,7 +256,7 @@ epics::pvData::PVLongPtr getLongField(const std::string& fieldName, const epics:
 epics::pvData::PVULongPtr getULongField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVULongPtr fieldPtr = pvStructurePtr->getULongField(fieldName);
+    epics::pvData::PVULongPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVULong>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not an unsigned long");
     }
@@ -266,7 +266,7 @@ epics::pvData::PVULongPtr getULongField(const std::string& fieldName, const epic
 epics::pvData::PVFloatPtr getFloatField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVFloatPtr fieldPtr = pvStructurePtr->getFloatField(fieldName);
+    epics::pvData::PVFloatPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVFloat>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a float");
     }
@@ -276,7 +276,7 @@ epics::pvData::PVFloatPtr getFloatField(const std::string& fieldName, const epic
 epics::pvData::PVDoublePtr getDoubleField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVDoublePtr fieldPtr = pvStructurePtr->getDoubleField(fieldName);
+    epics::pvData::PVDoublePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVDouble>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a double");
     }
@@ -286,7 +286,7 @@ epics::pvData::PVDoublePtr getDoubleField(const std::string& fieldName, const ep
 epics::pvData::PVStringPtr getStringField(const std::string& fieldName, const epics::pvData::PVStructurePtr& pvStructurePtr) 
 {
     checkFieldExists(fieldName, pvStructurePtr);
-    epics::pvData::PVStringPtr fieldPtr = pvStructurePtr->getStringField(fieldName);
+    epics::pvData::PVStringPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVString>(fieldName);
     if (!fieldPtr) {
         throw InvalidRequest("Field " + fieldName + " is not a string");
     }
@@ -367,73 +367,73 @@ void pyObjectToScalarField(const boost::python::object& pyObject, const std::str
     epics::pvData::ScalarType scalarType = getScalarType(fieldName, pvStructurePtr);
     switch (scalarType) {
         case epics::pvData::pvBoolean: {
-            epics::pvData::PVBooleanPtr fieldPtr = pvStructurePtr->getBooleanField(fieldName);
+            epics::pvData::PVBooleanPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVBoolean>(fieldName);
             bool value = PyUtility::extractValueFromPyObject<bool>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::boolean>(value));
             break;
         }
         case epics::pvData::pvByte: {
-            epics::pvData::PVBytePtr fieldPtr = pvStructurePtr->getByteField(fieldName);
+            epics::pvData::PVBytePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVByte>(fieldName);
             char value = PyUtility::extractValueFromPyObject<char>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::int8>(value));
             break;
         }
         case epics::pvData::pvUByte: {
-            epics::pvData::PVUBytePtr fieldPtr = pvStructurePtr->getUByteField(fieldName);
+            epics::pvData::PVUBytePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUByte>(fieldName);
             unsigned char value = PyUtility::extractValueFromPyObject<unsigned char>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::uint8>(value));
             break;
         }
         case epics::pvData::pvShort: {
-            epics::pvData::PVShortPtr fieldPtr = pvStructurePtr->getShortField(fieldName);
+            epics::pvData::PVShortPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVShort>(fieldName);
             short value = PyUtility::extractValueFromPyObject<short>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::int16>(value));
             break;
         }
         case epics::pvData::pvUShort: {
-            epics::pvData::PVUShortPtr fieldPtr = pvStructurePtr->getUShortField(fieldName);
+            epics::pvData::PVUShortPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUShort>(fieldName);
             unsigned short value = PyUtility::extractValueFromPyObject<unsigned short>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::uint16>(value));
             break;
         }
         case epics::pvData::pvInt: {
-            epics::pvData::PVIntPtr fieldPtr = pvStructurePtr->getIntField(fieldName);
+            epics::pvData::PVIntPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVInt>(fieldName);
             int value = PyUtility::extractValueFromPyObject<int>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::int32>(value));
             break;
         }
         case epics::pvData::pvUInt: {
-            epics::pvData::PVUIntPtr fieldPtr = pvStructurePtr->getUIntField(fieldName);
+            epics::pvData::PVUIntPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVUInt>(fieldName);
             unsigned int value = PyUtility::extractValueFromPyObject<unsigned int>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::uint32>(value));
             break;
         }
         case epics::pvData::pvLong: {
-            epics::pvData::PVLongPtr fieldPtr = pvStructurePtr->getLongField(fieldName);
+            epics::pvData::PVLongPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVLong>(fieldName);
             long long value = PyUtility::extractValueFromPyObject<long long>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::int64>(value));
             break;
         }
         case epics::pvData::pvULong: {
-            epics::pvData::PVULongPtr fieldPtr = pvStructurePtr->getULongField(fieldName);
+            epics::pvData::PVULongPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVULong>(fieldName);
             unsigned long long value = PyUtility::extractValueFromPyObject<unsigned long long>(pyObject);
             fieldPtr->put(static_cast<epics::pvData::uint64>(value));
             break;
         }
         case epics::pvData::pvFloat: {
-            epics::pvData::PVFloatPtr fieldPtr = pvStructurePtr->getFloatField(fieldName);
+            epics::pvData::PVFloatPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVFloat>(fieldName);
             float value = PyUtility::extractValueFromPyObject<float>(pyObject);
             fieldPtr->put(value);
             break;
         }
         case epics::pvData::pvDouble: {
-            epics::pvData::PVDoublePtr fieldPtr = pvStructurePtr->getDoubleField(fieldName);
+            epics::pvData::PVDoublePtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVDouble>(fieldName);
             double value = PyUtility::extractValueFromPyObject<double>(pyObject);
             fieldPtr->put(value);
             break;
         }
         case epics::pvData::pvString: {
-            epics::pvData::PVStringPtr fieldPtr = pvStructurePtr->getStringField(fieldName);
+            epics::pvData::PVStringPtr fieldPtr = pvStructurePtr->getSubField<epics::pvData::PVString>(fieldName);
             std::string value = PyUtility::extractValueFromPyObject<std::string>(pyObject);
             fieldPtr->put(value);
             break;
@@ -1258,9 +1258,9 @@ void copyStructureToStructure(const epics::pvData::PVStructurePtr& srcPvStructur
 
 void copyStructureToStructure(const std::string& fieldName, const epics::pvData::PVStructurePtr& srcPvStructurePtr, epics::pvData::PVStructurePtr& destPvStructurePtr)
 {
-    epics::pvData::PVStructurePtr destPvStructurePtr2 = destPvStructurePtr->getStructureField(fieldName);
+    epics::pvData::PVStructurePtr destPvStructurePtr2 = destPvStructurePtr->getSubField<epics::pvData::PVStructure>(fieldName);
     if (destPvStructurePtr2) {
-        epics::pvData::PVStructurePtr srcPvStructurePtr2 = srcPvStructurePtr->getStructureField(fieldName);
+        epics::pvData::PVStructurePtr srcPvStructurePtr2 = srcPvStructurePtr->getSubField<epics::pvData::PVStructure>(fieldName);
         if (srcPvStructurePtr2) {
             copyStructureToStructure(srcPvStructurePtr2, destPvStructurePtr2);
         }
@@ -1326,86 +1326,86 @@ void copyScalarToStructure(const std::string& fieldName, epics::pvData::ScalarTy
 {
     switch (scalarType) {
         case epics::pvData::pvBoolean: {
-            epics::pvData::PVBooleanPtr fieldPtr = destPvStructurePtr->getBooleanField(fieldName);
+            epics::pvData::PVBooleanPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVBoolean>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getBooleanField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVBoolean>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvByte: {
-            epics::pvData::PVBytePtr fieldPtr = destPvStructurePtr->getByteField(fieldName);
+            epics::pvData::PVBytePtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVByte>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getByteField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVByte>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvUByte: {
-            epics::pvData::PVUBytePtr fieldPtr = destPvStructurePtr->getUByteField(fieldName);
+            epics::pvData::PVUBytePtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVUByte>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getUByteField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVUByte>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvShort: {
-            epics::pvData::PVShortPtr fieldPtr = destPvStructurePtr->getShortField(fieldName);
+            epics::pvData::PVShortPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVShort>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getShortField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVShort>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvUShort: {
-            epics::pvData::PVUShortPtr fieldPtr = destPvStructurePtr->getUShortField(fieldName);
+            epics::pvData::PVUShortPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVUShort>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getUShortField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVUShort>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvInt: {
-            epics::pvData::PVIntPtr fieldPtr = destPvStructurePtr->getIntField(fieldName);
+            epics::pvData::PVIntPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVInt>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getIntField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVInt>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvUInt: {
-            epics::pvData::PVUIntPtr fieldPtr = destPvStructurePtr->getUIntField(fieldName);
+            epics::pvData::PVUIntPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVUInt>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getUIntField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVUInt>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvLong: {
-            epics::pvData::PVLongPtr fieldPtr = destPvStructurePtr->getLongField(fieldName);
+            epics::pvData::PVLongPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVLong>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getLongField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVLong>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvULong: {
-            epics::pvData::PVULongPtr fieldPtr = destPvStructurePtr->getULongField(fieldName);
+            epics::pvData::PVULongPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVULong>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getULongField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVULong>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvFloat: {
-            epics::pvData::PVFloatPtr fieldPtr = destPvStructurePtr->getFloatField(fieldName);
+            epics::pvData::PVFloatPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVFloat>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getFloatField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVFloat>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvDouble: {
-            epics::pvData::PVDoublePtr fieldPtr = destPvStructurePtr->getDoubleField(fieldName);
+            epics::pvData::PVDoublePtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVDouble>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getDoubleField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVDouble>(fieldName)->get());
             }
             break;
         }
         case epics::pvData::pvString: {
-            epics::pvData::PVStringPtr fieldPtr = destPvStructurePtr->getStringField(fieldName);
+            epics::pvData::PVStringPtr fieldPtr = destPvStructurePtr->getSubField<epics::pvData::PVString>(fieldName);
             if (fieldPtr) {
-                fieldPtr->put(srcPvStructurePtr->getStringField(fieldName)->get());
+                fieldPtr->put(srcPvStructurePtr->getSubField<epics::pvData::PVString>(fieldName)->get());
             }
             break;
         }


### PR DESCRIPTION
<p>The non-template functions for getting subfields of a PVStructure, such as PVStructure::getIntField, have been marked as deprecated and now generate build warnings. I've replaced calls of these functions with calls of the template function getSubField, e.g. getSubField&lt;PVInt&gt;.</p>
