### PR TITLE
Install the pvaccess.so library under lib/python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ QtC-
 bin/
 lib/
 include/
-setup.*sh
 config.log
 configure/*.local
 **/O.*

--- a/README.txt
+++ b/README.txt
@@ -24,6 +24,9 @@ Nothing special needs to be done when building the EPICS4 CPP modules. Ensure
 that the EPICS Base installation you use for this module is the same one that
 was used to build the EPICS4 modules.
 
+This module has not been adapted for use on Microsoft Windows. Only Unix-like
+operating systems (e.g. Linux, MacOS, Solaris) are currently supported.
+
 
 Build
 =======
@@ -68,8 +71,15 @@ the following boost/python packages installed:
   boost-python-1.41.0-25.el6.x86_64
   python-devel-2.6.6-52.el6.x86_64
 
-Note that the "make configure" command also creates setup.(c)sh files
-that configure PYTHONPATH for using pvaccess python module, e.g.:
+2) Compile the pvaPy source. In the top level package directory run:
+
+  $ make
+
+This will create and install a loadable library named pvaccess.so under the
+lib/python directory which can be imported directly by Python.
+
+This also creates setup.(c)sh files in the bin/$EPICS_HOST_ARCH directory
+that configure PYTHONPATH for using the pvaccess Python module, e.g.:
 
   $ cat setup.sh
   #!/bin/sh
@@ -79,16 +89,20 @@ that configure PYTHONPATH for using pvaccess python module, e.g.:
   # modifies PYTHONPATH environment variable
   #
   if test -z "$PYTHONPATH" ; then
-      export PYTHONPATH=/home/epics/v4/pvaPy/lib/linux-x86_64
+      export PYTHONPATH=/home/epics/v4/pvaPy/lib/python/2.6/linux-x86_64
   else
-      export PYTHONPATH=/home/epics/v4/pvaPy/lib/linux-x86_64:$PYTHONPATH
+      export PYTHONPATH=/home/epics/v4/pvaPy/lib/python/2.6/linux-x86_64:$PYTHONPATH
   fi
 
-2) Compile the pvaPy source. In the top level package directory run:
+These files must be sourced to use, e.g.:
 
-  $ make
+  $ . /home/epics/v4/pvaPy/bin/linux-x86_64/setup.sh
+  $ echo $PYTHONPATH
+  /home/epics/v4/pvaPy/lib/python/2.6/linux-x86_64
 
-This will create a pvaccess.so library in lib/$EPICS_HOST_ARCH directory.
+  % source /home/epics/v4/pvaPy/bin/linux-x86_64/setup.csh
+  % echo $PYTHONPATH
+  /home/epics/v4/pvaPy/lib/python/2.6/linux-x86_64
 
 3) Generate Python html documentation (optional, requires sphinx):
 
@@ -108,8 +122,8 @@ For simple testing, do the following:
   $ cd $EPICS4_DIR/pvaSrv/testTop/iocBoot/testDbPv
   $ ../../bin/$EPICS_HOST_ARCH/testDbPv st.cmd
 
-2) Source setup file (or export PYTHONPATH=$PVAPY_DIR/lib/$EPICS_HOST_ARCH)
-and start python (python PVA module is called pvaccess):
+2) Source the setup file from $PVAPY_DIR/bin/$EPICS_HOST_ARCH
+and start python (the Python PVA module is called pvaccess):
 
   $ python
   >>> import pvaccess
@@ -136,7 +150,7 @@ and start python (python PVA module is called pvaccess):
       int value 5
 
 In the above, note that in addition to PV object classes like PvInt, one
-can also use standard python types as arguments for channel puts.
+can also use standard Python types as arguments for channel puts.
 
 
 Basic Usage: PV monitor
@@ -156,7 +170,7 @@ Basic Usage: PV monitor
   epics> dbpf 'float01' 11.1
   DBR_FLOAT:          11.1
 
-3) Monitor channel in python, passing in a subscriber object (function
+3) Monitor a channel in Python, passing in a subscriber object (function
 that processes PvObject instance):
 
   >>> c = pvaccess.Channel('float01')
@@ -206,7 +220,7 @@ Advanced Usage: RPC Server Class
 Example 1:
 ----------
 
-1) In a separate terminal, source environment file and start python:
+1) In a separate terminal, source the environment file and start python:
 
   $ python # in terminal 2
   >>> import pvaccess

--- a/src/pvaccess/Makefile
+++ b/src/pvaccess/Makefile
@@ -13,6 +13,16 @@ USR_CXXFLAGS += $(PVA_PY_CPPFLAGS)
 USR_LDFLAGS  += $(PVA_PY_LDFLAGS)
 USR_SYS_LIBS += $(PVA_PY_SYS_LIBS)
 
+# Set our library install location; /$(T_A) will be added
+INSTALL_LOCATION_LIB = $(INSTALL_LOCATION)/lib/python/$(PYTHON_VERSION)
+
+
+# Expand and install the setup shell scripts
+
+SCRIPTS_HOST = setup.sh setup.csh
+EXPANDFLAGS += -DPYLIB=$(abspath $(INSTALL_LOCATION_LIB))
+EXPAND += $(SCRIPTS:%=%@)
+
 
 # Build the Python pvaccess loadable library
 
@@ -25,6 +35,7 @@ ifeq ($(OS_CLASS),Darwin)
 # Python on Darwin needs the suffix .so
 LOADABLE_SHRLIB_SUFFIX = .so
 endif
+
 
 pvaccess_SRCS += pvaccess.cpp
 pvaccess_SRCS += CaClient.cpp

--- a/src/pvaccess/setup.csh@
+++ b/src/pvaccess/setup.csh@
@@ -1,0 +1,11 @@
+#!/bin/csh
+#
+# pvaPy csh setup script
+#
+# modifies PYTHONPATH environment variable
+#
+if ( ! $?PYTHONPATH ) then
+    setenv PYTHONPATH @PYLIB@/@ARCH@
+else
+    setenv PYTHONPATH @PYLIB@/@ARCH@:${PYTHONPATH}
+endif

--- a/src/pvaccess/setup.sh
+++ b/src/pvaccess/setup.sh
@@ -1,2 +1,0 @@
-export PATH=/home/oxygen/SVESELI/Work/SPXRF/support/epics4-dev/pvAccessCPP/bin/linux-x86_64:$PATH
-export PYTHONPATH=$PYTHONPATH:/home/oxygen/SVESELI/Work/SPXRF/dev/base/lib/linux-x86_64

--- a/src/pvaccess/setup.sh@
+++ b/src/pvaccess/setup.sh@
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# pvaPy sh setup script
+#
+# modifies PYTHONPATH environment variable
+#
+if test -z "$PYTHONPATH" ; then
+    export PYTHONPATH=@PYLIB@/@ARCH@
+else
+    export PYTHONPATH=@PYLIB@/@ARCH@:$PYTHONPATH
+fi

--- a/tools/autoconf/m4/ax_pva_py.m4
+++ b/tools/autoconf/m4/ax_pva_py.m4
@@ -139,53 +139,6 @@ AC_DEFUN([AX_PVA_PY],
     echo "PVA_PY_SYS_LIBS = $BOOST_PYTHON_LIB" >> $config_site_local
     echo "PVA_API_VERSION = $PVA_API_VERSION" >> $config_site_local
     echo "PVA_RPC_API_VERSION = $PVA_RPC_API_VERSION" >> $config_site_local
+    echo "PYTHON_VERSION := \$(shell python -c 'import sys; print sys.version[[:3]]')" >> $config_site_local
     AC_MSG_NOTICE([created $config_site_local file])
-
-    # create setup.sh
-    setup_sh=$PVA_PY_TOP/setup.sh
-    AC_MSG_CHECKING(for existing $setup_sh file)
-    if test -f $setup_sh; then
-        AC_MSG_RESULT([yes])
-        AC_MSG_NOTICE(will not overwrite $setup_sh file)
-    else
-        AC_MSG_RESULT([no])
-        cat >> $setup_sh << EOF
-#!/bin/sh
-# 
-# pvaPy sh setup script
-#
-# modifies PYTHONPATH environment variable
-#
-if test -z "\$PYTHONPATH" ; then
-    export PYTHONPATH=$PVA_PY_TOP/lib/$EPICS_HOST_ARCH
-else
-    export PYTHONPATH=$PVA_PY_TOP/lib/$EPICS_HOST_ARCH:\$PYTHONPATH
-fi
-EOF
-        AC_MSG_NOTICE([created $setup_sh file])
-    fi
-
-    # create setup.csh
-    setup_csh=$PVA_PY_TOP/setup.csh
-    AC_MSG_CHECKING(for existing $setup_csh file)
-    if test -f $setup_csh; then
-        AC_MSG_RESULT([yes])
-        AC_MSG_NOTICE(will not overwrite $setup_csh file)
-    else
-        AC_MSG_RESULT([no])
-        cat >> $setup_csh << EOF
-#!/bin/csh
-# 
-# pvaPy csh setup script
-#
-# modifies PYTHONPATH environment variable
-#
-if ( ! \$?PYTHONPATH ) then
-    setenv PYTHONPATH ${PVA_PY_TOP}/lib/${EPICS_HOST_ARCH}
-else
-    setenv PYTHONPATH ${PVA_PY_TOP}/lib/${EPICS_HOST_ARCH}:\${PYTHONPATH}
-endif
-EOF
-        AC_MSG_NOTICE([created $setup_csh file])
-    fi
 ])


### PR DESCRIPTION
Change the install directory for the loadable library to be
  $(INSTALL_LOCATION)/lib/python/$(PYTHON_VERSION)/$(T_A)
Move the creation of the setup.{csh,sh} scripts into the normal
source directory, and install them into the regular bin/$(T_A)
directory (since $PYTHONPATH now includes $EPICS_HOST_ARCH).
Update README.txt to match.

This resolves epics-base/pvaPy#4
