### PR TITLE
Autoconf fixes

### DIFF
--- a/tools/autoconf/configure.ac
+++ b/tools/autoconf/configure.ac
@@ -6,7 +6,7 @@ AX_PYTHON_DEVEL([>=2.6])
 AX_BOOST_BASE([1.40], [], [AC_MSG_ERROR(required Boost library version >= 1.40.)])
 AX_BOOST_PYTHON
 AX_EPICS_BASE([3.14.12])
-AX_EPICS4([4.4.0])
+AX_EPICS4([4.0.4])
 AX_PVA_PY([0.1])
 #AC_OUTPUT
 

--- a/tools/autoconf/m4/ax_epics4.m4
+++ b/tools/autoconf/m4/ax_epics4.m4
@@ -109,7 +109,7 @@ AC_DEFUN([AX_EPICS4],
 
     # check pvAccess version number
     export CPPFLAGS="$PVA_CPPFLAGS $EPICS_CPPFLAGS"
-    AC_PREPROC_IFELSE([
+    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
         #include "pv/pvaVersion.h"
         #undef VERSION_INT
         #undef PVA_VERSION_INT
@@ -118,7 +118,7 @@ AC_DEFUN([AX_EPICS4],
         #if PVA_VERSION_INT < VERSION_INT($pva_version_req_major,$pva_version_req_minor,$pva_version_req_patch)
         #  error too old
         #endif
-    ],[AC_MSG_RESULT([yes])],[
+    ]])],[AC_MSG_RESULT([yes])],[
         AC_MSG_RESULT([no])
         AC_MSG_ERROR("EPICS4 installation in $ac_epics4_dir_path is too old (required: pvAccess $pva_version_req)")
     ])

--- a/tools/autoconf/m4/ax_epics4.m4
+++ b/tools/autoconf/m4/ax_epics4.m4
@@ -4,11 +4,11 @@
 #
 # SYNOPSIS
 #
-#   AX_EPICS4([MINIMUM-VERSION])
+#   AX_EPICS4([MINIMUM-PVA-VERSION])
 #
 # DESCRIPTION
 #
-#   Test for the EPICS4 libraries of a particular version (or newer)
+#   Test for EPICS V4 libraries with a minimum pvAccess version
 #
 #   If no path to the installed epics4 directory is given, the macro 
 #   evaluates $EPICS4_DIR environment variable and searches under
@@ -29,7 +29,7 @@
 
 #serial 1
 
-DEFAULT_EPICS4_VERSION=4.4.0
+DEFAULT_PVA_VERSION=4.0.4
 
 AC_DEFUN([AX_EPICS4],
 
@@ -58,127 +58,121 @@ AC_DEFUN([AX_EPICS4],
         AC_MSG_ERROR($ac_epics4_dir_path is not a valid directory path)
     fi
 
-    pvaccesscpp_dir="$ac_epics4_dir_path/pvAccessCPP"
-    pvdatacpp_dir="$ac_epics4_dir_path/pvDataCPP"
-    normativetypescpp_dir="$ac_epics4_dir_path/normativeTypesCPP"
-    pvaclientcpp_dir="$ac_epics4_dir_path/pvaClientCPP"
+    # save compile/link flags, set lang to C++
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH([C++])
+    SAVED_CPPFLAGS="$CPPFLAGS"
+    SAVED_LDFLAGS="$LDFLAGS"
 
-    epics4_version_h="$pvaccesscpp_dir/include/pv/pvaVersionNum.h"
-    if ! test -f "$epics4_version_h"; then
-        pvaccesscpp_dir="$ac_epics4_dir_path"
+    # look for required v4 modules, assume common epics4 install dir if not found
+    pvdatacpp_dir="$ac_epics4_dir_path/pvDataCPP"
+    if ! test -d "$pvdatacpp_dir"; then
         pvdatacpp_dir="$ac_epics4_dir_path"
+    fi
+    pvaccesscpp_dir="$ac_epics4_dir_path/pvAccessCPP"
+    if ! test -d "$pvaccesscpp_dir"; then
+        pvaccesscpp_dir="$ac_epics4_dir_path"
+    fi
+    normativetypescpp_dir="$ac_epics4_dir_path/normativeTypesCPP"
+    if ! test -d "$normativetypescpp_dir"; then
         normativetypescpp_dir="$ac_epics4_dir_path"
+    fi
+    pvaclientcpp_dir="$ac_epics4_dir_path/pvaClientCPP"
+    if ! test -d "$pvaclientcpp_dir"; then
         pvaclientcpp_dir="$ac_epics4_dir_path"
-        epics4_version_h="$pvaccesscpp_dir/include/pv/pvaVersion.h"
     fi
 
-    if ! test -f "$epics4_version_h"; then
+    pva_version_h="$pvaccesscpp_dir/include/pv/pvaVersion.h"
+    if ! test -f "$pva_version_h"; then
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR(could not find valid EPICS4 installation in $ac_epics4_dir_path: no version header file $epics_version_h)
+        AC_MSG_ERROR("could not find pvAccess installation: no header file $epics_version_h")
     fi
     AC_MSG_RESULT([yes])
 
     # define EPICS4_DIR
     EPICS4_DIR=$ac_epics4_dir_path
 
-    # determine requested version
-    epics4_version_req=ifelse([$1], , $DEFAULT_EPICS4_VERSION, $1)
-    AC_MSG_CHECKING(for EPICS4 >= $epics4_version_req)
-    epics4_version_req_major=`expr $epics4_version_req : '\([[0-9]]*\)'`
-    epics4_version_req_minor=`expr $epics4_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
-    epics4_version_req_sub_minor=`expr $epics4_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-    if test "x$epics4_version_req_sub_minor" = "x" ; then
-        epics4_version_req_sub_minor="0"
-        epics4_version_req_patch="0"
-    else
-        epics4_version_req_patch=`expr $epics4_version_req : '[[0-9]]*\.[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-        if test "x$epics4_version_req_patch" = "x" ; then
-            epics4_version_req_patch="0"
-        fi
+    # determine required version
+    pva_version_req=ifelse([$1], , $DEFAULT_PVA_VERSION, $1)
+    AC_MSG_CHECKING(for pvAccess version >= $pva_version_req)
+    pva_version_req_major=`expr $pva_version_req : '\([[0-9]]*\)'`
+    pva_version_req_minor=`expr $pva_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
+    pva_version_req_patch=`expr $pva_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+    if test "x$pva_version_req_patch" == "x" ; then
+        pva_version_req_patch="0"
     fi
 
-    # get epics4 version info
-    # assume release version is always 4
-    epics4_version_release=4
-    epics4_version_major=`grep EPICS_PVA_MAJOR_VERSION $epics4_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
-    epics4_version_minor=`grep EPICS_PVA_MINOR_VERSION $epics4_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
-    epics4_version_maintenance=`grep EPICS_PVA_MAINTENANCE_VERSION $epics4_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
+    # options for building with pvData & pvAccess
+    PVA_CPPFLAGS="-I$pvdatacpp_dir/include -I$pvaccesscpp_dir/include"
+    PVA_LDFLAGS="-L$pvdatacpp_dir/lib/$EPICS_HOST_ARCH -L$pvaccesscpp_dir/lib/$EPICS_HOST_ARCH"
+    PVA_LIBS="-lpvAccess -lpvData -lCom"
 
-    # test version
-    want_epics4_version=`expr $epics4_version_req_major \* 1000000 \+  $epics4_version_req_minor \* 10000 \+ $epics4_version_req_sub_minor \* 100 \+ $epics4_version_req_patch`
-    have_epics4_version=`expr $epics4_version_release \* 1000000 \+  $epics4_version_major \* 10000 \+ $epics4_version_minor \* 100 \+ $epics4_version_maintenance`
-    if ! test $have_epics4_version -ge $want_epics4_version; then
+    # check pvAccess version number
+    export CPPFLAGS="$PVA_CPPFLAGS $EPICS_CPPFLAGS"
+    AC_PREPROC_IFELSE([
+        #include "pv/pvaVersion.h"
+        #undef VERSION_INT
+        #undef PVA_VERSION_INT
+        #define VERSION_INT(V,M,P) (((V)<<16) | ((M)<<8) | (P))
+        #define PVA_VERSION_INT VERSION_INT(EPICS_PVA_MAJOR_VERSION,EPICS_PVA_MINOR_VERSION,EPICS_PVA_MAINTENANCE_VERSION)
+        #if PVA_VERSION_INT < VERSION_INT($pva_version_req_major,$pva_version_req_minor,$pva_version_req_patch)
+        #  error too old
+        #endif
+    ],[AC_MSG_RESULT([yes])],[
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR("EPICS4 installation in $ac_epics4_dir_path is too old (required: $want_epics4_version, found: $have_epics4_version)")
-    fi
-    AC_MSG_RESULT([yes])
+        AC_MSG_ERROR("EPICS4 installation in $ac_epics4_dir_path is too old (required: pvAccess $pva_version_req)")
+    ])
 
     # test basic libraries
-    AC_MSG_CHECKING(for usable EPICS4 libraries for $EPICS_OS_CLASS OS ($EPICS_CMPLR_CLASS compiler) and host architecture $EPICS_HOST_ARCH)
-
+    AC_MSG_CHECKING(for EPICS4 libraries for $EPICS_HOST_ARCH)
     pva_api_version=430
     pva_rpc_api_version=430
-    CPPFLAGS_SAVED="$CPPFLAGS"
-    CPPFLAGS="$CPPFLAGS $EPICS_CPPFLAGS -I$EPICS_BASE/include -I$EPICS_BASE/include/os/$EPICS_OS_CLASS -I$EPICS_BASE/include/compiler/$EPICS_CMPLR_CLASS -I$pvdatacpp_dir/include -I$pvaccesscpp_dir/include"
-    export CPPFLAGS
 
-    LDFLAGS_SAVED="$LDFLAGS"
-    LDFLAGS="$LDFLAGS $EPICS_LDFLAGS"
-    LDFLAGS="$LDFLAGS -L$EPICS_BASE/lib/$EPICS_HOST_ARCH -L$pvdatacpp_dir/lib/$EPICS_HOST_ARCH -L$pvaccesscpp_dir/lib/$EPICS_HOST_ARCH"
-    export LDFLAGS
+    export LDFLAGS="$PVA_LDFLAGS $EPICS_LDFLAGS"
+    export LIBS="$PVA_LIBS"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/pvAccess.h"
+        #include "pv/pvData.h"
+        ]],
+        [[
+        epics::pvData::FieldConstPtrArray fields;
+        ]])
+    ],[succeeded=yes],[succeeded=no])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/pvAccess.h"
+        #include "pv/pvData.h"
+        class RequesterImpl : public epics::pvData::Requester
+        {
+        public:
+            RequesterImpl(const epics::pvData::String& requesterName) {}
+            virtual epics::pvData::String getRequesterName() { return "requester"; }
+            virtual void message(const epics::pvData::String& message, epics::pvData::MessageType messageType) {}
+        };
+        ]],
+        [[
+        epics::pvData::Requester::shared_pointer requester(new RequesterImpl("Channel"));
+        epics::pvData::PVStructure::shared_pointer pvRequest = epics::pvAccess::getCreateRequest()->createRequest("field(value)", requester);
+        ]])
+    ],[pva_api_version=430],[pva_api_version=440])
 
-    LIBS="-lpvAccess -lpvData -lCom"
-    export LIBS
+    # options for building with normativeTypes & pvaClient
+    PVAC_CPPFLAGS="-I$normativetypescpp_dir/include -I$pvaclientcpp_dir/include"
+    PVAC_LDFLAGS="-L$pvaclientcpp_dir/lib/$EPICS_HOST_ARCH -L$normativetypescpp_dir/lib/$EPICS_HOST_ARCH"
+    PVAC_LIBS="-lpvaClient -lnt"
 
-    succeeded=no
-    AC_REQUIRE([AC_PROG_CXX])
-    AC_LANG_PUSH([C++])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[
-            #include "pv/pvAccess.h"
-            #include "pv/pvData.h"
-            ]],
-            [[
-            epics::pvData::FieldConstPtrArray fields;
-            ]])
-        ],[succeeded=yes],[succeeded=no])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[
-            #include "pv/pvAccess.h"
-            #include "pv/pvData.h"
-            class RequesterImpl : public epics::pvData::Requester
-            {
-            public:
-                RequesterImpl(const epics::pvData::String& requesterName) {}
-                virtual epics::pvData::String getRequesterName() { return "requester"; }
-                virtual void message(const epics::pvData::String& message, epics::pvData::MessageType messageType) {}
-            };
-            ]],
-            [[
-            epics::pvData::Requester::shared_pointer requester(new RequesterImpl("Channel"));
-            epics::pvData::PVStructure::shared_pointer pvRequest = epics::pvAccess::getCreateRequest()->createRequest("field(value)", requester);
-            ]])
-        ],[pva_api_version=430],[pva_api_version=440])
-    AC_LANG_POP([C++])
-
-    # Check for pvaClient API
-    CPPFLAGS_NO_PVACLIENTCPP=$CPPFLAGS
-    CPPFLAGS="$CPPFLAGS -I$normativetypescpp_dir/include -I$pvaclientcpp_dir/include"
-    LDFLAGS_NO_PVACLIENTCPP=$LDFLAGS
-    LDFLAGS="$LDFLAGS -L$pvaclientcpp_dir/lib/$EPICS_HOST_ARCH -L$normativetypescpp_dir/lib/$EPICS_HOST_ARCH"
-    LIBS_NO_PVACLIENTCPP=$LIBS
-    LIBS="-lpvaClient -lpvAccess -lnt -lpvData -lCom"
-    AC_REQUIRE([AC_PROG_CXX])
-    AC_LANG_PUSH([C++])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[
-            #include "pv/pvaClient.h"
-            ]],
-            [[
-            epics::pvaClient::PvaClientChannelPtr pvaClientChannel;
-            ]])
-        ],[pva_client_cpp=yes],[pva_client_cpp=no])
-    AC_LANG_POP([C++])
+    export CPPFLAGS="$PVAC_CPPFLAGS $PVA_CPPFLAGS $EPICS_CPPFLAGS"
+    export LDFLAGS="$PVAC_LDFLAGS $PVA_LDFLAGS $EPICS_LDFLAGS"
+    export LIBS="$PVAC_LIBS $PVA_LIBS"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/pvaClient.h"
+        ]],
+        [[
+        epics::pvaClient::PvaClientChannelPtr pvaClientChannel;
+        ]])
+    ],[pva_client_cpp=yes],[pva_client_cpp=no])
 
     if test "$succeeded" != "yes" ; then
         AC_MSG_RESULT([no])
@@ -200,41 +194,37 @@ AC_DEFUN([AX_EPICS4],
         AC_SUBST(PVACCESSCPP_DIR, $pvaccesscpp_dir)
     fi
 
-    CPPFLAGS=$CPPFLAGS_NO_PVACLIENTCPP
-    LDFLAGS=$LDFLAGS_NO_PVACLIENTCPP
-    LIBS=$LIBS_NO_PVACLIENTCPP
+    export CPPFLAGS="$PVA_CPPFLAGS $EPICS_CPPFLAGS"
+    export LDFLAGS="$PVA_LDFLAGS $EPICS_LDFLAGS"
+    export LIBS="$PVA_LIBS"
     AC_MSG_CHECKING(EPICS4 PVA RPC API version)
-    succeeded=no
-    AC_REQUIRE([AC_PROG_CXX])
-    AC_LANG_PUSH([C++])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[
-            #include "pv/pvAccess.h"
-            #include "pv/pvData.h"
-            #include "pv/event.h"
-            #include "pv/rpcClient.h"
-            ]],
-            [[
-            epics::pvAccess::RPCClient::shared_pointer rpcClient;
-            ]])
-        ],[succeeded=yes],[succeeded=no])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[
-            #include "pv/rpcClient.h"
-            ]],
-            [[
-            epics::pvAccess::RPCClientFactory::create("Channel");
-            ]])
-        ],[pva_rpc_api_version1=430],[pva_rpc_api_version1=undefined])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[
-            #include "pv/rpcClient.h"
-            ]],
-            [[
-            epics::pvAccess::RPCClient::create("Channel");
-            ]])
-        ],[pva_rpc_api_version3=440],[pva_rpc_api_version3=undefined])
-    AC_LANG_POP([C++])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/pvAccess.h"
+        #include "pv/pvData.h"
+        #include "pv/event.h"
+        #include "pv/rpcClient.h"
+        ]],
+        [[
+        epics::pvAccess::RPCClient::shared_pointer rpcClient;
+        ]])
+    ],[succeeded=yes],[succeeded=no])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/rpcClient.h"
+        ]],
+        [[
+        epics::pvAccess::RPCClientFactory::create("Channel");
+        ]])
+    ],[pva_rpc_api_version1=430],[pva_rpc_api_version1=undefined])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/rpcClient.h"
+        ]],
+        [[
+        epics::pvAccess::RPCClient::create("Channel");
+        ]])
+    ],[pva_rpc_api_version3=440],[pva_rpc_api_version3=undefined])
 
     pva_rpc_api_version="undefined"
     if test "$pva_rpc_api_version1" != "undefined" ; then
@@ -255,7 +245,8 @@ AC_DEFUN([AX_EPICS4],
         AC_SUBST(PVA_RPC_API_VERSION, $pva_rpc_api_version)
     fi
 
-    CPPFLAGS="$CPPFLAGS_SAVED"
-    LDFLAGS="$LDFLAGS_SAVED"
-
+    # restore compile/link flags
+    CPPFLAGS="$SAVED_CPPFLAGS"
+    LDFLAGS="$SAVED_LDFLAGS"
+    AC_LANG_POP([C++])
 ])

--- a/tools/autoconf/m4/ax_epics_base.m4
+++ b/tools/autoconf/m4/ax_epics_base.m4
@@ -19,8 +19,8 @@
 #     HAVE_EPICS
 #     EPICS_BASE
 #     EPICS_HOST_ARCH
-#     EPICS_OS_CLASS
-#     EPICS_CMPLR_CLASS
+#     EPICS_CPPFLAGS
+#     EPICS_LDFLAGS
 #
 # LICENSE
 #
@@ -31,7 +31,7 @@
 
 #serial 1
 
-DEFAULT_EPICS_VERSION=3.14.1
+DEFAULT_EPICS_VERSION=3.14.12
 
 AC_DEFUN([AX_EPICS_BASE],
 
@@ -60,44 +60,16 @@ AC_DEFUN([AX_EPICS_BASE],
         AC_MSG_ERROR($ac_epics_base_path is not a valid directory path)
     fi
 
+    # save compile/link flags, set lang to C++
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH([C++])
+    SAVED_CPPFLAGS="$CPPFLAGS"
+    SAVED_LDFLAGS="$LDFLAGS"
+
     epics_version_h="$ac_epics_base_path/include/epicsVersion.h"
     if ! test -f "$epics_version_h"; then
         AC_MSG_RESULT([no])
         AC_MSG_ERROR(could not find valid EPICS base installation in $ac_epics_base_path: no version header file $epics_version_h)
-    fi
-    AC_MSG_RESULT([yes])
-
-    # define EPICS_BASE
-    EPICS_BASE=$ac_epics_base_path
-
-    # determine requested version
-    epics_version_req=ifelse([$1], , $DEFAULT_EPICS_VERSION, $1)
-    AC_MSG_CHECKING(for EPICS base >= $epics_version_req)
-    epics_version_req_major=`expr $epics_version_req : '\([[0-9]]*\)'`
-    epics_version_req_minor=`expr $epics_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
-    epics_version_req_sub_minor=`expr $epics_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-    if test "x$epics_version_req_sub_minor" = "x" ; then
-        epics_version_req_sub_minor="0"
-        epics_version_req_patch="0"
-    else
-        epics_version_req_patch=`expr $epics_version_req : '[[0-9]]*\.[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-        if test "x$epics_version_req_patch" = "x" ; then
-            epics_version_req_patch="0"
-        fi
-    fi
-
-    # get epics version info
-    epics_version_major=`grep EPICS_VERSION $epics_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
-    epics_version_minor=`grep EPICS_REVISION $epics_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
-    epics_version_sub_minor=`grep EPICS_MODIFICATION $epics_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
-    epics_version_patch=`grep EPICS_PATCH_LEVEL $epics_version_h | head -1 | awk '{print $NF}' | sed $'s/\r//'`
-
-    # test version
-    want_epics_version=`expr $epics_version_req_major \* 1000000 \+  $epics_version_req_minor \* 10000 \+ $epics_version_req_sub_minor \* 100 \+ $epics_version_req_patch`
-    have_epics_version=`expr $epics_version_major \* 1000000 \+  $epics_version_minor \* 10000 \+ $epics_version_sub_minor \* 100 \+ $epics_version_patch`
-    if ! test $have_epics_version -ge $want_epics_version; then
-        AC_MSG_RESULT([no])
-        AC_MSG_ERROR("EPICS base installation in $ac_epics_base_path is too old (required: $want_epics_version, found: $have_epics_version)")
     fi
     AC_MSG_RESULT([yes])
 
@@ -109,36 +81,73 @@ AC_DEFUN([AX_EPICS_BASE],
         AC_MSG_ERROR(could not determine EPICS host architecture)
     fi
 
+    # define EPICS_BASE
+    EPICS_BASE=$ac_epics_base_path
+
+    # determine required version
+    epics_version_req=ifelse([$1], , $DEFAULT_EPICS_VERSION, $1)
+    AC_MSG_CHECKING(for EPICS Base version >= $epics_version_req)
+    req_epics_version=`expr $epics_version_req : '\([[0-9]]*\)'`
+    req_epics_revision=`expr $epics_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
+    req_epics_modification=`expr $epics_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+    if test "x$req_epics_modification" = "x" ; then
+        req_epics_modification="0"
+        req_epics_patch_level="0"
+    else
+        epics_version_req_patch=`expr $epics_version_req : '[[0-9]]*\.[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+        if test "x$req_epics_patch_level" = "x" ; then
+            req_epics_patch_level="0"
+        fi
+    fi
+
+    # Search include directory only, sufficient for epicsVersion.h
+    EPICS_CPPFLAGS="$CMD_CPPFLAGS -I$EPICS_BASE/include"
+    CPPFLAGS="$SAVED_CPPFLAGS $EPICS_CPPFLAGS"
+
+    # check epics version
+    AC_PREPROC_IFELSE([
+        #include "epicsVersion.h"
+        #ifndef VERSION_INT
+        #  define VERSION_INT(V,R,M,P) (((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+        #  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION,EPICS_REVISION,EPICS_MODIFICATION,EPICS_PATCH_LEVEL)
+        #endif
+        #if EPICS_VERSION_INT < VERSION_INT($req_epics_version,$req_epics_revision,$req_epics_modification,$req_epics_patch_level)
+        #  error too old
+        #endif
+    ],[AC_MSG_RESULT([yes])],[
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR("EPICS Base installation in $ac_epics_base_path is too old (required: $epics_version_req)")
+    ])
+
     # test basic libraries
     # need to determine OS class first
     epics_host_arch_main=`echo $EPICS_HOST_ARCH | cut -f1 -d'-'`
     EPICS_OS_CLASS=`grep OS_CLASS $EPICS_BASE/configure/os/CONFIG.*Common.${epics_host_arch_main}* | head -1 | awk '{print $NF}'`
+    if test -d "$EPICS_BASE/include/os/$EPICS_OS_CLASS"; then
+        EPICS_CPPFLAGS="$EPICS_CPPFLAGS -I$EPICS_BASE/include/os/$EPICS_OS_CLASS"
+    fi
+
     # need to determine CMPLR_CLASS, which is *hard*, so
-    # TODO: remove this hardcoded setting with the correct one from the EPICS configure directory
-    EPICS_CMPLR_CLASS=gcc
-    AC_MSG_CHECKING(for usable EPICS base libraries for $EPICS_OS_CLASS OS ($EPICS_CMPLR_CLASS compiler) and host architecture $EPICS_HOST_ARCH)
+    # TODO: replace these hardcoded settings with the correct one from the EPICS configure directory
+    if test "$epics_host_arch_main" = "linux" ; then
+        EPICS_CMPLR_CLASS=gcc
+    elif test "$epics_host_arch_main" = "darwin" ; then
+        EPICS_CMPLR_CLASS=clang
+    fi
+    AC_MSG_CHECKING(for EPICS Base libraries for $EPICS_HOST_ARCH)
 
-    succeeded=no
-    CPPFLAGS_SAVED="$CPPFLAGS"
-    CPPFLAGS="$CPPFLAGS $EPICS_CPPFLAGS -I$EPICS_BASE/include -I$EPICS_BASE/include/os/$EPICS_OS_CLASS -I$EPICS_BASE/include/compiler/$EPICS_CMPLR_CLASS"
-    export CPPFLAGS
+    EPICS_CPPFLAGS="$EPICS_CPPFLAGS -I$EPICS_BASE/include/compiler/$EPICS_CMPLR_CLASS"
+    export CPPFLAGS="$SAVED_CPPFLAGS $EPICS_CPPFLAGS"
 
-    LDFLAGS_SAVED="$LDFLAGS"
-    LDFLAGS="$LDFLAGS $EPICS_LDFLAGS"
-    #LDFLAGS="$LDFLAGS -L$EPICS_BASE/lib/$EPICS_HOST_ARCH -lca"
-    LDFLAGS="$LDFLAGS -L$EPICS_BASE/lib/$EPICS_HOST_ARCH"
-    export LDFLAGS
+    EPICS_LDFLAGS="-L$EPICS_BASE/lib/$EPICS_HOST_ARCH"
+    export LDFLAGS="$SAVED_LDFLAGS $EPICS_LDFLAGS"
 
-    export LIBS="-lca"
-    export LIBS
+    export LIBS="-lca -lCom"
 
-    AC_REQUIRE([AC_PROG_CXX])
-    AC_LANG_PUSH([C++])
-        AC_LINK_IFELSE([AC_LANG_PROGRAM(
-            [[#include <cadef.h>]],
-            [[ca_context_create(ca_enable_preemptive_callback);]])
-        ],[succeeded=yes],[succeeded=no])
-    AC_LANG_POP([C++])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[#include <cadef.h>]],
+        [[ca_context_create(ca_enable_preemptive_callback);]])
+    ],[succeeded=yes],[succeeded=no])
 
     if test "$succeeded" != "yes" ; then
         AC_MSG_RESULT([no])
@@ -148,11 +157,12 @@ AC_DEFUN([AX_EPICS_BASE],
         AC_DEFINE(HAVE_EPICS, , [define if the EPICS base is available])
         AC_SUBST(EPICS_BASE)
         AC_SUBST(EPICS_HOST_ARCH)
-        AC_SUBST(EPICS_OS_CLASS)
-        AC_SUBST(EPICS_CMPLR_CLASS)
+        AC_SUBST(EPICS_CPPFLAGS)
+        AC_SUBST(EPICS_LDFLAGS)
     fi
 
-    CPPFLAGS="$CPPFLAGS_SAVED"
-    LDFLAGS="$LDFLAGS_SAVED"
-
+    # restore compile/link flags
+    CPPFLAGS="$SAVED_CPPFLAGS"
+    LDFLAGS="$SAVED_LDFLAGS"
+    AC_LANG_POP([C++])
 ])

--- a/tools/autoconf/m4/ax_epics_base.m4
+++ b/tools/autoconf/m4/ax_epics_base.m4
@@ -105,7 +105,7 @@ AC_DEFUN([AX_EPICS_BASE],
     CPPFLAGS="$SAVED_CPPFLAGS $EPICS_CPPFLAGS"
 
     # check epics version
-    AC_PREPROC_IFELSE([
+    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
         #include "epicsVersion.h"
         #ifndef VERSION_INT
         #  define VERSION_INT(V,R,M,P) (((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
@@ -114,7 +114,7 @@ AC_DEFUN([AX_EPICS_BASE],
         #if EPICS_VERSION_INT < VERSION_INT($req_epics_version,$req_epics_revision,$req_epics_modification,$req_epics_patch_level)
         #  error too old
         #endif
-    ],[AC_MSG_RESULT([yes])],[
+    ]])],[AC_MSG_RESULT([yes])],[
         AC_MSG_RESULT([no])
         AC_MSG_ERROR("EPICS Base installation in $ac_epics_base_path is too old (required: $epics_version_req)")
     ])


### PR DESCRIPTION
@sveseli This has some fairly big changes in it so I thought you should get a chance to look at them before it gets merged. I think it resolves both issues and should build properly on Cloudbees.
- Andrew

Version headers are now checked using the C preprocessor.
The ax_epics_base component now exports EPICS_CFLAGS and EPICS_LDFLAGS
instead of the lower-level variables.
The ax_epics4 component now takes the required pvAccess version number
instead of the overall EPICS V4 package version.
Some reorganization internally, to simplify the components.

Fixes #14 and #15
