### PR TITLE
Better handling of python exceptions from monitor callback

### DIFF
--- a/src/pvaccess/Channel.440.cpp
+++ b/src/pvaccess/Channel.440.cpp
@@ -521,7 +521,10 @@ void Channel::callSubscribers(PvObject& pvObject)
             pySubscriber(pvObject);
         }
         catch(const boost::python::error_already_set&) {
-            logger.error("Channel subscriber " + subscriberName + " error");
+            PyErr_Print();
+            PyErr_Clear();
+            logger.error("Channel subscriber " + subscriberName + " throws python exception.  unsubscribing.");
+            unsubscribe(subscriberName);
         }
 
         // Release GIL. 

--- a/src/pvaccess/Channel.450.cpp
+++ b/src/pvaccess/Channel.450.cpp
@@ -559,7 +559,10 @@ void Channel::callSubscribers(PvObject& pvObject)
             pySubscriber(pvObject);
         }
         catch(const boost::python::error_already_set&) {
-            logger.error("Channel subscriber " + subscriberName + " error");
+            PyErr_Print();
+            PyErr_Clear();
+            logger.error("Channel subscriber " + subscriberName + " throws python exception.  unsubscribing.");
+            unsubscribe(subscriberName);
         }
 
         // Release GIL. 


### PR DESCRIPTION
Print the python exception and unsubscribe().  Properly ignore with PyErr_Clear().
