### PR TITLE
Avoid use of monitor elements after release()

### DIFF
--- a/src/pvaccess/Channel.450.cpp
+++ b/src/pvaccess/Channel.450.cpp
@@ -654,9 +654,11 @@ void Channel::monitorThread(Channel* channel)
     logger.debug("Started monitor thread %s", epicsThreadGetNameSelf());
     epics::pvaClient::PvaClientMonitorPtr monitor = channel->getMonitor();
     epics::pvaClient::PvaClientMonitorDataPtr pvaData = monitor->getData();
+    epics::pvData::PVDataCreatePtr create(epics::pvData::getPVDataCreate());
     while (channel->shutdownThreads == false) {
         monitor->waitEvent();
-        PvObject pvObject(pvaData->getPVStructure());
+        epics::pvData::PVStructurePtr C(create->createPVStructure(pvaData->getPVStructure())); // copy
+        PvObject pvObject(C);
         channel->queueMonitorData(pvObject);
         monitor->releaseEvent();
     }


### PR DESCRIPTION
Monitor consumers are not allowed to access elements after release() as they may be reused.  So make a copy as a quick fix for #20.
