### PR TITLE
Add specifying the pvRequest structure in RPC client

### DIFF
--- a/src/pvaccess/RpcClient.h
+++ b/src/pvaccess/RpcClient.h
@@ -20,13 +20,16 @@ public:
     static const int DefaultTimeout;
 
     RpcClient(const std::string& channelName);
+#if defined PVA_RPC_API_VERSION && PVA_RPC_API_VERSION == 460
+    RpcClient(const std::string& channelName, const PvObject& pvRequestObject);
+#endif
     RpcClient(const RpcClient& pvaRpcClient);
     std::string getChannelName() const;
 
     virtual ~RpcClient();
     virtual epics::pvData::PVStructurePtr request(const epics::pvData::PVStructurePtr& pvRequest, double timeout=DefaultTimeout);
     //virtual PvObject* request(const PvObject& pvObject, double timeout=DefaultTimeout);
-    virtual PvObject* invoke(const PvObject& pvObject);
+    virtual PvObject* invoke(const PvObject& pvArgumentObject);
 
 private:
     static epics::pvAccess::RPCClient::shared_pointer createRpcClient(const std::string& channelName, const epics::pvData::PVStructurePtr& pvRequest, double timeout=DefaultTimeout);
@@ -35,6 +38,7 @@ private:
     bool rpcClientInitialized;
     epics::pvAccess::RPCClient::shared_pointer rpcClient;
     std::string channelName;
+    epics::pvData::PVStructure::shared_pointer pvRequest;
 };
 
 inline std::string RpcClient::getChannelName() const

--- a/src/pvaccess/pvaccess.RpcClient.cpp
+++ b/src/pvaccess/pvaccess.RpcClient.cpp
@@ -15,25 +15,33 @@ void wrapRpcClient()
 
 class_<RpcClient>("RpcClient", 
     "RpcClient is a client class for PVA RPC services.\n\n"
+#if defined PVA_RPC_API_VERSION && PVA_RPC_API_VERSION == 460
+    "**RpcClient(channelName[, pvRequest])**\n\n"
+    "\t:Parameter: *channelName* (str) - RPC service channel name\n\n"
+    "\t:Parameter: *pvRequest* (PvObject) - pvRequest object specifying structure sent on creating RPC if default structure not used\n\n"
+#else
     "**RpcClient(channelName)**\n\n"
     "\t:Parameter: *channelName* (str) - RPC service channel name\n\n"
+#endif
     "\tThis example creates RPC client for channel 'createNtTable':\n\n"
     "\t::\n\n"
     "\t\trpcClient = RpcClient('createNtTable')\n\n", 
     init<std::string>())
-
+#if defined PVA_RPC_API_VERSION && PVA_RPC_API_VERSION == 460
+    .def(init<std::string, const PvObject&>())
+#endif
     .def("invoke", 
         &RpcClient::invoke, 
         return_value_policy<manage_new_object>(), 
-        args("pvRequest"), 
+        args("pvArgument"), 
         "Invokes RPC call against service registered on the PV specified channel.\n\n"
-        ":Parameter: *pvRequest* (PvObject) - PV request object with a structure conforming to requirements of the RPC service registered on the given PV channel\n\n"
+        ":Parameter: *pvArgument* (PvObject) - PV argument object with a structure conforming to requirements of the RPC service registered on the given PV channel\n\n"
         ":Returns: PV response object\n\n"
         "The following code works with the above RPC service example:\n\n"
         "::\n\n"
-        "    pvRequest = PvObject({'nRows' : INT, 'nColumns' : INT})\n\n"
-        "    pvRequest.set({'nRows' : 10, 'nColumns' : 10})\n\n"
-        "    pvResponse = rpcClient(pvRequest)\n\n"
+        "    pvArgument = PvObject({'nRows' : INT, 'nColumns' : INT})\n\n"
+        "    pvArgument.set({'nRows' : 10, 'nColumns' : 10})\n\n"
+        "    pvResponse = rpcClient(pvArgument)\n\n"
         "    ntTable = NtTable(pvResponse)\n\n")
 ;
 

--- a/src/pvaccess/pvaccess.RpcClient.cpp
+++ b/src/pvaccess/pvaccess.RpcClient.cpp
@@ -34,7 +34,7 @@ class_<RpcClient>("RpcClient",
         "    pvRequest = PvObject({'nRows' : INT, 'nColumns' : INT})\n\n"
         "    pvRequest.set({'nRows' : 10, 'nColumns' : 10})\n\n"
         "    pvResponse = rpcClient(pvRequest)\n\n"
-        "    ntTable = NtTable(pvRequest)\n\n")
+        "    ntTable = NtTable(pvResponse)\n\n")
 ;
 
 } // wrapRpcClient()

--- a/tools/autoconf/m4/ax_epics4.m4
+++ b/tools/autoconf/m4/ax_epics4.m4
@@ -225,10 +225,23 @@ AC_DEFUN([AX_EPICS4],
         epics::pvAccess::RPCClient::create("Channel");
         ]])
     ],[pva_rpc_api_version3=440],[pva_rpc_api_version3=undefined])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+        #include "pv/rpcClient.h"
+        #include "pv/createRequest.h"
+        ]],
+        [[
+        epics::pvAccess::RPCClient::create("Channel");
+        epics::pvAccess::RPCClient::create("Channel",
+            epics::pvData::CreateRequest::create()->createRequest(""));
+        ]])
+    ],[pva_rpc_api_version4=460],[pva_rpc_api_version4=undefined])
 
     pva_rpc_api_version="undefined"
     if test "$pva_rpc_api_version1" != "undefined" ; then
         pva_rpc_api_version=$pva_rpc_api_version1
+    elif test "$pva_rpc_api_version4" != "undefined" ; then
+        pva_rpc_api_version=$pva_rpc_api_version4
     elif test "$pva_rpc_api_version3" != "undefined" ; then
         pva_rpc_api_version=$pva_rpc_api_version3
     fi


### PR DESCRIPTION
Add ability to specify the pvRequest structure sent when creating the channel RPC in RPC client. Retain the old API supplying default structure.

autoconf has been modified to check for 4.6 API. Backwards compatibility with previous versions 4.4, 4.5 is ensured through macros.

There seemed to be some confusion between the structure sent when creating the channel RPC and the structure sent when calling the remote procedure. This distinction has been made clearer through careful naming.

One fix to the documentation has also been made in pvaccess.RpcClient.cpp (NtTable needs the table structure received as a response in the example, not the call arguments).
