### PR TITLE
Add ability to set type ID in structures and structure arrays

### DIFF
--- a/src/pvaccess/PyPvDataUtility.cpp
+++ b/src/pvaccess/PyPvDataUtility.cpp
@@ -1624,10 +1624,22 @@ void addStructureField(const std::string& fieldName, const boost::python::dict& 
     names.push_back(fieldName);
 }
 
+void addStructureField(const std::string& fieldName, const PvObject & pvObject, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names)
+{
+    fields.push_back(pvObject.getPvStructurePtr()->getStructure());
+    names.push_back(fieldName);   
+}
+
 void addStructureArrayField(const std::string& fieldName, const boost::python::dict& pyDict, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names)
 {
     fields.push_back(epics::pvData::getFieldCreate()->createStructureArray(createStructureFromDict(pyDict)));
     names.push_back(fieldName);
+}
+
+void addStructureArrayField(const std::string& fieldName, const PvObject & pvObject, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names)
+{
+    fields.push_back(epics::pvData::getFieldCreate()->createStructureArray(pvObject.getPvStructurePtr()->getStructure()));
+    names.push_back(fieldName);   
 }
 
 void addUnionField(const std::string& fieldName, const boost::python::dict& pyDict, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names)
@@ -1806,7 +1818,7 @@ bool updateFieldArrayFromPvObject(const boost::python::object& pyObject, const s
             break;
         }
         default: {
-            addStructureField(fieldName, pyDict2, fields, names);
+            addStructureField(fieldName, pvObject, fields, names);
         }
     }
     return true;
@@ -1836,7 +1848,7 @@ bool updateFieldArrayFromPvObjectList(const boost::python::object& pyObject, con
             break;
         }
         default: {
-            addStructureArrayField(fieldName, pyDict2, fields, names);
+            addStructureArrayField(fieldName, pvObject, fields, names);
         }
     }
     return true;

--- a/src/pvaccess/PyPvDataUtility.h
+++ b/src/pvaccess/PyPvDataUtility.h
@@ -20,6 +20,8 @@
 #include "PyUtility.h"
 #include "InvalidDataType.h"
 
+class PvObject;
+
 namespace PyPvDataUtility
 {
 
@@ -273,7 +275,9 @@ epics::pvData::PVStructurePtr createUnionFieldPvStructure(epics::pvData::UnionCo
 void addScalarField(const std::string& fieldName, epics::pvData::ScalarType scalarType, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
 void addScalarArrayField(const std::string& fieldName, epics::pvData::ScalarType scalarType, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
 void addStructureField(const std::string& fieldName, const boost::python::dict& pyDict, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
+void addStructureField(const std::string& fieldName, const PvObject & pvObject, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
 void addStructureArrayField(const std::string& fieldName, const boost::python::dict& pyDict, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
+void addStructureArrayField(const std::string& fieldName, const PvObject & pvObject, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
 void addUnionField(const std::string& fieldName, const boost::python::dict& pyDict, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
 void addUnionArrayField(const std::string& fieldName, const boost::python::dict& pyDict, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);
 void addVariantUnionField(const std::string& fieldName, epics::pvData::FieldConstPtrArray& fields, epics::pvData::StringArray& names);

--- a/src/pvaccess/pvaccess.PvObject.cpp
+++ b/src/pvaccess/pvaccess.PvObject.cpp
@@ -17,7 +17,7 @@ void wrapPvObject()
 
 class_<PvObject>("PvObject", 
     "PvObject represents a generic PV structure.\n\n"
-    "**PvObject(structureDict [,valueDict])**\n\n"
+    "**PvObject(structureDict [,valueDict][,typeId])**\n\n"
     "\t:Parameter: *structureDict* (dict) - dictionary of key:value pairs describing the underlying PV structure in terms of field names and their types\n\n"
     "\tThe dictionary key is a string (PV field name), and value is one of:\n\n"
     "\t- PVTYPE: scalar type, can be BOOLEAN, BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG, FLOAT, DOUBLE, or STRING\n"
@@ -30,6 +30,7 @@ class_<PvObject>("PvObject",
     "\t- [({key:value, ...},)]: single element list representing restricted union array\n\n"
     "\t:Parameter: *valueDict* (dict) - (optional) dictionary of key:value pairs to be used to set field values in the underlying PV structure\n\n"
     "\t:Raises: *InvalidArgument* - in case structure dictionary cannot be parsed\n\n"
+    "\t:Parameter: *typeId* (str) - (optional) The type ID string of the PV structure\n\n"
     "\tExamples of PvObject initialization: ::\n\n"
     "\t\tpv1 = PvObject({'anInt' : INT})\n\n"
     "\t\tpv2 = PvObject({'aShort' : SHORT, 'anUInt' : UINT, 'aString' : STRING})\n\n"
@@ -37,6 +38,7 @@ class_<PvObject>("PvObject",
     "\t\tpv4 = PvObject({'aStructArray' : [{'anInt' : INT, 'anInt2' : INT, 'aDouble' : DOUBLE}]})\n\n" 
     "\t\tpv5 = PvObject({'anUnion' : ({'anInt' : INT, 'aDouble' : DOUBLE},)})\n\n" 
     "\t\tpv6 = PvObject({'aVariant' : ()})\n\n" 
+    "\t\tpv7 = PvObject({'value' : DOUBLE}, 'epics:nt/NTScalar:1.0')\n\n"
     "\tIn addition to various set/get methods described below,\n"
     "\tPvObject elements can be accessed and manipulated similar to dictionaries: ::\n\n"
     "\t\t>>> pv = PvObject({'a' : {'b' : STRING, 'c' : FLOAT}}, {'a' : {'b' : 'my string', 'c' : 10.1}})\n"
@@ -87,7 +89,12 @@ class_<PvObject>("PvObject",
     "\n\n", 
     init<boost::python::dict>(args("structureDict")))
 
+    .def(init<boost::python::dict,const std::string &>(args("structureDict","typeId")))
+
     .def(init<boost::python::dict,boost::python::dict>(args("structureDict","valueDict")))
+
+
+    .def(init<boost::python::dict,boost::python::dict,const std::string>(args("structureDict","valueDict","typeId")))
 
     .def_pickle(PvObjectPickleSuite())
 


### PR DESCRIPTION
It appears that currently the type ID cannot be set when creating a structure (#25).

1) Add ability to create a structure with non default type ID

``` Python
struc1 = PvObject({ 'leaf' : DOUBLE }, 'type')
struc2 = PvObject({ 'leaf' : DOUBLE }, { 'leaf' : 3.14159 }, 'type')
```

by exposing the existing C++ constructors.

2) With the current implementation this does not allow retaining the type ID when nesting structures as the latter are converted to dictionaries. So

``` Python
struc3 = PvObject({ 'leaf'   : DOUBLE }, 'type3')
struc2 = PvObject({ 'struc3' : struc3 }, 'type2')
struc1 = PvObject({ 'struc2' : struc2 }, 'type1')
```

produces

<pre>
type1 
    structure struc2
        structure struc3
            double leaf 0
</pre>


Change this to retain the type ID by adding the structure to the list of fields directly, without converting to a dictionary, giving in the above case:

<pre>
type1 
    type2 struc2
        type3 struc3
            double leaf 0
</pre>


3) Provide a similar fix for structure arrays. So for example

``` Python
struc3 = PvObject({'leaf' : DOUBLE }, 'type3')
struc2 = PvObject({ 'struc3' : [ struc3 ] }, 'type2')
struc1 = PvObject({ 'struc2' : [ struc2 ] }, 'type1')
struc1['struc2'] =  [ { 'struc3' : [ { 'leaf' : 3.14159 } ] } ]
```

produces

<pre>
type1 
    type2[] struc2
        type2 
            type3[] struc3
                type3 
                    double leaf 3.14159
</pre>

