### PR TITLE
FIX: Changing Python version comparison from StrictVersion to LooseVersion

### DIFF
--- a/tools/autoconf/m4/ax_python_devel.m4
+++ b/tools/autoconf/m4/ax_python_devel.m4
@@ -117,9 +117,9 @@ to something else than an empty string.
 	if test -n "$1"; then
 		AC_MSG_CHECKING([for a version of Python $1 $2])
 		ac_supports_python_ver=`$PYTHON -c "import sys; \
-            from distutils.version import StrictVersion; \
+            from distutils.version import LooseVersion; \
 			ver = sys.version.split ()[[0]]; \
-			print (StrictVersion(ver) $1 StrictVersion('$2'))"`
+			print (LooseVersion(ver) $1 LooseVersion('$2'))"`
 		if test "$ac_supports_python_ver" = "True"; then
 		   AC_MSG_RESULT([yes])
 		else


### PR DESCRIPTION
Due to some bugs with weird Python versions, e.g. 2.7.12+.

As reported by @arkilic, see https://gist.github.com/arkilic/77443a88a77abce029064c6cc21ca828, after the changes he faced an error when compiling pvaPy under system python in ubuntu 16.04 LTS.

@arkilic, please test again with your system that was presenting the error. I did some tests and it works for me here.
