### PR TITLE
Changed AC_MSG_ERROR to AC_MSG_FAILURE for build failures

### DIFF
--- a/tools/autoconf/m4/ax_epics4.m4
+++ b/tools/autoconf/m4/ax_epics4.m4
@@ -89,7 +89,7 @@ AC_DEFUN([AX_EPICS4],
     pva_version_h="$pvaccesscpp_dir/include/pv/pvaVersion.h"
     if ! test -f "$pva_version_h"; then
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR("could not find pvAccess installation: no header file $epics_version_h")
+        AC_MSG_ERROR("could not find pvAccess installation: no header file $pva_version_h")
     fi
     AC_MSG_RESULT([yes])
 
@@ -180,7 +180,7 @@ AC_DEFUN([AX_EPICS4],
 
     if test "$succeeded" != "yes" ; then
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR(could not compile and link EPICS4 test code: check your EPICS4 installation)
+        AC_MSG_FAILURE(could not compile and link EPICS4 test code: check your EPICS4 installation)
     else
         AC_SUBST(NORMATIVETYPESCPP_DIR, "")
         AC_SUBST(PVACLIENTCPP_DIR, "")
@@ -253,7 +253,7 @@ AC_DEFUN([AX_EPICS4],
 
     if test "$succeeded" != "yes" ; then
         AC_MSG_RESULT([unknown])
-        AC_MSG_ERROR(could not compile and link EPICS4 RPC test code: check your EPICS4 installation)
+        AC_MSG_FAILURE(could not compile and link EPICS4 RPC test code: check your EPICS4 installation)
     elif test "$pva_rpc_api_version" == "undefined" ; then
         AC_MSG_RESULT([unknown])
         AC_MSG_ERROR(could not determine EPICS4 RPC API version: check your EPICS4 installation)

--- a/tools/autoconf/m4/ax_epics_base.m4
+++ b/tools/autoconf/m4/ax_epics_base.m4
@@ -151,7 +151,7 @@ AC_DEFUN([AX_EPICS_BASE],
 
     if test "$succeeded" != "yes" ; then
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR(could not compile and link EPICS test code: check your EPICS base installation)
+        AC_MSG_FAILURE(could not compile and link EPICS test code: check your EPICS base installation)
     else
         AC_MSG_RESULT([yes])
         AC_DEFINE(HAVE_EPICS, , [define if the EPICS base is available])


### PR DESCRIPTION
Produces a config.log for debugging along w/ a msg:
See config.log for more details.

Also fixed pva_version_h typo.