### PR TITLE
added addRecord to pvaServer so we can host more pvs than only one

### DIFF
--- a/src/pvaccess/PvaServer.cpp
+++ b/src/pvaccess/PvaServer.cpp
@@ -32,3 +32,18 @@ void PvaServer::update(const PvObject& pvObject)
 {
     record->update(pvObject);
 }
+
+void PvaServer::addRecord(const std::string& channelName, const PvObject& pvObject)
+{
+
+    epics::pvDatabase::PVDatabasePtr master = epics::pvDatabase::PVDatabase::getMaster();
+    PyPvRecordPtr myrecord(PyPvRecord::create(channelName, pvObject));
+    
+    if(!master->addRecord(myrecord)) {
+        throw PvaException("Cannot add record to master database for channel: " + channelName);
+    }
+
+}
+
+
+

--- a/src/pvaccess/PvaServer.h
+++ b/src/pvaccess/PvaServer.h
@@ -18,6 +18,7 @@ public:
     PvaServer(const std::string& channelName, const PvObject& pvObject);
     virtual ~PvaServer();
     virtual void update(const PvObject& pvObject);
+    virtual void addRecord(const std::string& channelName, const PvObject& pvObject);
 private:
     static PvaPyLogger logger;
     epics::pvAccess::ServerContext::shared_pointer server;

--- a/src/pvaccess/pvaccess.PvaServer.cpp
+++ b/src/pvaccess/pvaccess.PvaServer.cpp
@@ -32,7 +32,15 @@ class_<PvaServer>("PvaServer",
         "::\n\n"
         "    pv2 = PvObject({'x' : INT, 'y' : INT}, {'x' : 3, 'y' : 5})\n\n"
         "    pvaServer.update(pv2)\n\n")
+
+    .def("addRecord",
+        static_cast<void(PvaServer::*)(const std::string&,const PvObject&)>(&PvaServer::addRecord),
+        args("pvName","pvObject"),
+        "adds pv to server.\n\n"
+        ":Parameters: pvname, *pvObject* (PvObject) -\n\n"
+        )
 ;
 
+    //virtual void addRecord(const std::string& channelName, const PvObject& pvObject);
 } // wrapPvaServer()
 


### PR DESCRIPTION
I want to host a bunch of pvs on a python shell for a detector controlled by python. I edited the pvaPy so PvaServer has addRecord(str, PvObject) method to add more pvs to master dB. The update method will still only update the original pv that was declared on init(). Not sure what update is for anyway, as just changing the original PvObject updates the pv online anyway.

Here is py example:
import time
from pvaccess import INT, PvaServer, PvObject
pv = PvObject({'x': INT, 'y' : INT})
pvaServer = PvaServer('pair', pv)
pv2 = PvObject({'x': INT, 'y' : INT})
pvaServer.addRecord('p2',pv2)
pv2['x']=100
pv2['x']=101
pv['x']=101
pv['y']=101

Both pvs show up on another terminal running:
pvget -m p2 pair 

It also seems to work w/ arrays.

Tim Madden
APS Argonne
