### PR TITLE
Add monitor thread synchronization.

### DIFF
--- a/src/pvaccess/Channel.450.h
+++ b/src/pvaccess/Channel.450.h
@@ -157,6 +157,7 @@ private:
     std::string monitorRequestDescriptor;
 
     bool monitorActive;
+    bool monitorThreadRunning;
     bool processingThreadRunning;
     SynchronizedQueue<PvObject> pvObjectQueue;
 
@@ -171,6 +172,7 @@ private:
     epics::pvData::Mutex monitorMutex;
     epics::pvData::Mutex processingThreadMutex;
     epicsEvent processingThreadExitEvent;
+    epicsEvent monitorThreadExitEvent;
     double timeout;
     PvProvider::ProviderType providerType;
 


### PR DESCRIPTION
In case monitorStart() and monitorStop() are being called close
together and before the monitor thread was able to connect, several
different segfaults were observed either in monitorStartThread()
function pointing to destroyed channel pointer or in stopMonitor()
using non-initialized pvaClientMonitorRequesterPtr.
The synchronization waits indefinetely for monitor thread to stop
before proceeding to stop the monitor. Timeout is already enforced
in the thread calling ::connect().