### PR TITLE
remove calls to deprecated methods of pvaClientCPP.

### DIFF
--- a/src/pvaccess/Channel.450.cpp
+++ b/src/pvaccess/Channel.450.cpp
@@ -34,7 +34,7 @@ const double Channel::MonitorStartWaitTime(0.1);
 PvaPyLogger Channel::logger("Channel");
 PvaClient Channel::pvaClient;
 CaClient Channel::caClient;
-epics::pvaClient::PvaClientPtr Channel::pvaClientPtr(epics::pvaClient::PvaClient::create());
+epics::pvaClient::PvaClientPtr Channel::pvaClientPtr(epics::pvaClient::PvaClient::get());
 
 
 Channel::Channel(const std::string& channelName, PvProvider::ProviderType providerType_) :

--- a/src/pvaccess/Channel.460.cpp
+++ b/src/pvaccess/Channel.460.cpp
@@ -905,7 +905,9 @@ void Channel::onChannelConnect()
         pvaClientMonitorRequesterPtr = epics::pvaClient::PvaClientMonitorRequesterPtr(new ChannelMonitorRequesterImpl(getName(), this));
 
         //pvaClientMonitorPtr = pvaClientChannelPtr->monitor(monitorRequestDescriptor, pvaClientMonitorRequesterPtr);
-        pvaClientMonitorPtr = epics::pvaClient::PvaClientMonitor::create(pvaClientPtr, getName(), PvProvider::getProviderName(providerType), monitorRequestDescriptor, epics::pvaClient::PvaClientChannelStateChangeRequesterPtr(), pvaClientMonitorRequesterPtr);
+       pvaClientMonitorPtr =  pvaClientChannelPtr->createMonitor(monitorRequestDescriptor);
+       pvaClientMonitorPtr->setRequester(pvaClientMonitorRequesterPtr);
+       pvaClientMonitorPtr->issueConnect();
         monitorRunning = true;
     } 
     catch (PvaException& ex) {

--- a/src/pvaccess/testPvaClient.cpp
+++ b/src/pvaccess/testPvaClient.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
         runtime = atoi(argv[1]);
     }
 
-    epics::pvaClient::PvaClientPtr pvaClientPtr(epics::pvaClient::PvaClient::create());
+    epics::pvaClient::PvaClientPtr pvaClientPtr(epics::pvaClient::PvaClient::get());
 
     std::string channelName = "X1";
     epics::pvaClient::PvaClientChannelPtr pvaClientChannelPtr(pvaClientPtr->createChannel(channelName, "pva"));


### PR DESCRIPTION
The methods are:
static PvaClientPtr create() EPICS_DEPRECATED;
and
static PvaClientMonitorPtr create(
    PvaClientPtr const &pvaClient,
    std::string const & channelName,
    std::string const & providerName,
    std::string const & request,
    PvaClientChannelStateChangeRequesterPtr const & stateChangeRequester
            = PvaClientChannelStateChangeRequesterPtr(),
    PvaClientMonitorRequesterPtr const & monitorRequester
            = PvaClientMonitorRequesterPtr()
) EPICS_DEPRECATED;