### PR TITLE
fix race condition in issueConnectThread

### DIFF
--- a/src/pvaccess/Channel.482.cpp
+++ b/src/pvaccess/Channel.482.cpp
@@ -951,9 +951,8 @@ void Channel::processingThread(Channel* channel)
 void Channel::issueConnectThread(Channel* channel)
 {
     logger.debug("About to issue channel connect in a thread %s", epicsThreadGetNameSelf());
+    channel->callConnectionCallback(false);
     channel->issueConnect();
-    bool isConnected = channel->isChannelConnected();
-    channel->callConnectionCallback(isConnected);
 }
 
 //


### PR DESCRIPTION
When setConnectionCallback is called and the channel exists the client should see

     connected false
     connected true

but sometimes the order is reversed

     connected true
     connected false

The push request fixes this problem